### PR TITLE
Remove unnecessary uses of objectpath#get

### DIFF
--- a/app/scripts/components/collections/ingest.js
+++ b/app/scripts/components/collections/ingest.js
@@ -8,6 +8,7 @@ import omit from 'lodash.omit';
 import { getCollection } from '../../actions';
 import { fullDate, lastUpdated } from '../../utils/format';
 import config from '../../config';
+import Loading from '../app/loading-indicator';
 
 var CollectionIngest = React.createClass({
   displayName: 'CollectionIngest',
@@ -26,7 +27,7 @@ var CollectionIngest = React.createClass({
 
   componentWillReceiveProps: function (props) {
     const collectionName = props.params.collectionName;
-    const record = get(this.props.collections, ['map', collectionName]);
+    const record = this.props.collections.map[collectionName];
     if (!record) {
       this.get(collectionName);
     }
@@ -61,12 +62,9 @@ var CollectionIngest = React.createClass({
 
   render: function () {
     const collectionName = this.props.params.collectionName;
-    const record = get(this.props.collections, ['map', collectionName]);
-    if (!record) {
-      return <div></div>;
-    } else if (record.inflight) {
-      // TODO loading indicator
-      return <div></div>;
+    const record = this.props.collections.map[collectionName];
+    if (!record || (record.inflight && !record.data)) {
+      return <Loading />;
     }
     const { data } = record;
     return (

--- a/app/scripts/components/collections/overview.js
+++ b/app/scripts/components/collections/overview.js
@@ -78,7 +78,7 @@ var CollectionOverview = React.createClass({
   render: function () {
     const collectionName = this.props.params.collectionName;
     const { granules, collections } = this.props;
-    const record = get(collections.map, collectionName);
+    const record = collections.map[collectionName];
     const { list } = granules;
     const { meta } = list;
 

--- a/app/scripts/components/granules/granule.js
+++ b/app/scripts/components/granules/granule.js
@@ -69,7 +69,7 @@ var GranuleOverview = React.createClass({
 
   componentWillMount: function () {
     const { granuleId } = this.props.params;
-    const immediate = !get(this.props.granules.map, granuleId);
+    const immediate = !this.props.granules.map[granuleId];
     this.reload(immediate);
   },
 
@@ -133,9 +133,9 @@ var GranuleOverview = React.createClass({
 
   render: function () {
     const granuleId = this.props.params.granuleId;
-    const record = get(this.props.granules.map, granuleId);
+    const record = this.props.granules.map[granuleId];
 
-    if (record.inflight && !record.data) {
+    if (!record || (record.inflight && !record.data)) {
       return <Loading />;
     }
 

--- a/app/scripts/components/granules/recipe-ingest.js
+++ b/app/scripts/components/granules/recipe-ingest.js
@@ -20,18 +20,16 @@ var GranuleRecipe = React.createClass({
 
   componentWillMount: function () {
     const granuleId = this.props.params.granuleId;
-    if (!get(this.props.granules.map, granuleId)) {
+    if (!this.props.granules.map[granuleId]) {
       this.props.dispatch(getGranule(granuleId));
     }
   },
 
   render: function () {
     const granuleId = this.props.params.granuleId;
-    const record = get(this.props.granules, ['map', granuleId]);
+    const record = this.props.granules.map[granuleId];
 
-    if (!record) {
-      return <div></div>;
-    } else if (record.inflight) {
+    if (!record || (record.inflight && !record.data)) {
       return <Loading />;
     }
 


### PR DESCRIPTION
Fix #143 
Modis names use `.` as a separator, ie `MYD13A1.A2017025.h16v06.006.2017046151149`.
Objectpath#get will treat this as several layers of properties to access, ie `map['MYD13A1']['A2017025']...`

