### PR TITLE
Hide read-only form fields, closes #164, closes #226

### DIFF
--- a/app/scripts/components/form/schema.js
+++ b/app/scripts/components/form/schema.js
@@ -25,6 +25,9 @@ export const createFormConfig = function (data, schema) {
   data = data || {};
   const fields = [];
   traverseSchema(schema, function (property, meta, schemaProperty, path) {
+    // If a field isn't user-editable, hide it from the form
+    if (meta.readonly) { return; }
+
     // determine the label
     const required = Array.isArray(schemaProperty.required) &&
       schemaProperty.required.indexOf(property) >= 0;


### PR DESCRIPTION
The form will still _submit_ the same, because it does a deep merge of the user-edited form data with the payload _received_ from the API.

This is probably a priority to deploy to the production site, since it makes this week's LP DAAC testing using the forms much quicker and less error-prone; they've definitely been slowed down by that today.