### PR TITLE
Allow ordering of dumb tables, closes #200

### DIFF
--- a/app/scripts/components/granules/granule.js
+++ b/app/scripts/components/granules/granule.js
@@ -250,7 +250,12 @@ var GranuleOverview = React.createClass({
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium heading--shared-content with-description'>Files</h2>
           </div>
-          <SortableTable data={files} header={tableHeader} row={tableRow}/>
+          <SortableTable
+            data={files}
+            header={tableHeader}
+            row={tableRow}
+            props={['name', 'sipFile', 'stagingFile', 'archivedFile', 'access']}
+          />
         </section>
 
         <section className='page__section'>

--- a/app/scripts/components/resources/index.js
+++ b/app/scripts/components/resources/index.js
@@ -77,7 +77,12 @@ var Resources = React.createClass({
               </div>
             </div>
             <div className='row'>
-              <SortableTable data={queues} header={queueConfig.tableHeader} row={queueConfig.tableRow}/>
+              <SortableTable
+                data={queues}
+                header={queueConfig.tableHeader}
+                row={queueConfig.tableRow}
+                props={['name', 'messagesAvailable', 'messagesInFlight']}
+                />
             </div>
           </section>
 
@@ -88,7 +93,12 @@ var Resources = React.createClass({
               </div>
             </div>
             <div className='row'>
-              <SortableTable data={services} header={serviceConfig.tableHeader} row={serviceConfig.tableRow}/>
+              <SortableTable
+                data={services}
+                header={serviceConfig.tableHeader}
+                row={serviceConfig.tableRow}
+                props={['name', 'status', 'desiredCount', 'pendingCount', 'runningCount']}
+                />
             </div>
           </section>
 
@@ -99,7 +109,12 @@ var Resources = React.createClass({
               </div>
             </div>
             <div className='row'>
-              <SortableTable data={instances} header={instanceConfig.tableHeader} row={instanceConfig.tableRow}/>
+              <SortableTable
+                data={instances}
+                header={instanceConfig.tableHeader}
+                row={instanceConfig.tableRow}
+                props={['id', 'status', 'pendingTasks', 'runningTasks', 'availableCpu', 'availableMemory']}
+                />
             </div>
           </section>
         </div>


### PR DESCRIPTION
Tried implementing as if they were all smart tables, but ran into large design problems, including a lack of pagination options and no easy way to de-dup data-loading for multiple dumb tables that used the same data-fetching action. This is pretty clean, in the end.