### PR TITLE
CUMULUS-515: allow batch-async-command to collect multiple errors and continue with the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- batch-async-command now collects all errors in a queue, rather than emptying the queue after the first error
+
 ## [v1.1.0] - 2018-04-20
 ### Added
 - Expandable errors. [CUMULUS-394]

--- a/app/scripts/components/form/batch-async-command.js
+++ b/app/scripts/components/form/batch-async-command.js
@@ -18,7 +18,8 @@ const BatchCommand = React.createClass({
     className: PropTypes.string,
     onSuccess: PropTypes.func,
     onError: PropTypes.func,
-    confirm: PropTypes.func
+    confirm: PropTypes.func,
+    updateDelay: PropTypes.number
   },
 
   getInitialState: function () {
@@ -77,17 +78,19 @@ const BatchCommand = React.createClass({
 
   // immediately change the UI to show either success or error
   onComplete: function (errors, results) {
-    console.log(errors, results)
+    const delay = this.props.updateDelay ? this.props.updateDelay : updateDelay;
     // turn array of errors from queue into single error for ui
     const error = this.createErrorMessage(errors);
     this.setState({status: (error ? 'error' : 'success')});
-    setTimeout(() => this.cleanup(error, results), updateDelay);
+    setTimeout(() => {
+      this.cleanup(error, results);
+    }, delay);
   },
 
   // combine multiple errors into one
   createErrorMessage: function (errors) {
     if (!errors || !errors.length) return;
-    return `${errors.map((err) => err.toString()).join('\n')}`;
+    return `${errors.length} errors occurred: \n${errors.map((err) => err.error.toString()).join('\n')}`;
   },
 
   // call onSuccess and onError functions as needed

--- a/app/scripts/components/form/batch-async-command.js
+++ b/app/scripts/components/form/batch-async-command.js
@@ -1,7 +1,7 @@
 'use strict';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { queue } from 'd3-queue';
+import queue from 'stubborn-queue';
 import AsyncCommand from './async-command';
 import { updateDelay } from '../../config';
 
@@ -61,9 +61,9 @@ const BatchCommand = React.createClass({
       this.isInflight()) return false;
     const q = queue(CONCURRENCY);
     for (let i = 0; i < selection.length; ++i) {
-      q.defer(this.initAction, selection[i]);
+      q.add(this.initAction, selection[i]);
     }
-    q.awaitAll(this.onComplete);
+    q.done(this.onComplete);
   },
 
   // save a reference to the callback in state, then init the action
@@ -76,9 +76,18 @@ const BatchCommand = React.createClass({
   },
 
   // immediately change the UI to show either success or error
-  onComplete: function (error, results) {
+  onComplete: function (errors, results) {
+    console.log(errors, results)
+    // turn array of errors from queue into single error for ui
+    const error = this.createErrorMessage(errors);
     this.setState({status: (error ? 'error' : 'success')});
     setTimeout(() => this.cleanup(error, results), updateDelay);
+  },
+
+  // combine multiple errors into one
+  createErrorMessage: function (errors) {
+    if (!errors || !errors.length) return;
+    return `${errors.map((err) => err.toString()).join('\n')}`;
   },
 
   // call onSuccess and onError functions as needed
@@ -86,7 +95,7 @@ const BatchCommand = React.createClass({
     const { onSuccess, onError } = this.props;
     this.setState({ activeModal: false, completed: 0, status: null });
     if (error && typeof onError === 'function') onError(error);
-    else if (!error && typeof onSuccess === 'function') onSuccess(results);
+    if (results && results.length && typeof onSuccess === 'function') onSuccess(results);
   },
 
   isInflight: function () {

--- a/app/scripts/components/table/list-view.js
+++ b/app/scripts/components/table/list-view.js
@@ -129,7 +129,7 @@ var List = React.createClass({
   },
 
   onBulkActionError: function (error) {
-    const message = `Could not process ${error.id}, ${error.error}`;
+    const message = (error.id && error.error) ? `Could not process ${error.id}, ${error.error}` : error;
     this.setState({
       bulkActionError: message,
       selected: []

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "envify": "^3.4.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-15": "^1.0.5",
+    "enzyme-redux": "^0.2.1",
     "eslint": "^2.9.0",
     "eslint-config-standard": "^5.3.1",
     "eslint-plugin-promise": "^1.1.0",
@@ -122,6 +123,7 @@
     "redux-thunk": "^2.2.0",
     "request": "^2.79.0",
     "shortid": "^2.2.6",
-    "slugify": "^1.1.0"
+    "slugify": "^1.1.0",
+    "stubborn-queue": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "envify": "^3.4.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-15": "^1.0.5",
-    "enzyme-redux": "^0.2.1",
     "eslint": "^2.9.0",
     "eslint-config-standard": "^5.3.1",
     "eslint-plugin-promise": "^1.1.0",

--- a/test/components/form/batch-async-command.js
+++ b/test/components/form/batch-async-command.js
@@ -4,9 +4,6 @@ import test from 'ava';
 import Adapter from 'enzyme-adapter-react-15';
 import React from 'react';
 import { shallow, configure } from 'enzyme';
-import { connect } from 'react-redux';
-import { shallowWithStore } from 'enzyme-redux';
-import { createMockStore } from 'redux-test-utils';
 
 import BatchCommand from '../../../app/scripts/components/form/batch-async-command.js';
 
@@ -15,54 +12,71 @@ configure({ adapter: new Adapter() });
 test('collect multiple errors', function (t) {
   const noop = () => {}
 
-  const onSuccess = (result) => {
-    console.log(result)
-  };
+  return new Promise((resolve, reject) => {
+    const selection = [
+      '0-error',
+      '1-pass',
+      '2-error',
+      '3-pass'
+    ];
 
-  const onError = (err) => {
-    console.log(err)
-  };
-
-  const action = (id) => {
-    item.state[id] = {
-      status: id.contains('error') ? 'error' : 'success'
+    let count = 0
+    const done = () => {
+      count++
+      if (count == 2) {
+        resolve()
+      }
     }
 
-    command.newProps(item)
-  }
+    const onSuccess = (result) => {
+      t.is(result.filter((item) => !!item).length, 2)
+      done()
+    };
 
-  const item = {
-    text: 'Example',
-    action: action,
-    state: {},
-    confirm: noop
-  }
+    const onError = (err) => {
+      t.is(err.indexOf('2 errors occurred'), 0)
+      done()
+    };
 
-  const selected = [
-    '0-error',
-    '1-pass',
-    '2-error',
-    '3-pass'
-  ];
+    const action = (id) => {
+      if (id.indexOf('error') > 0) {
+        item.state[id] = {
+          status: 'error',
+          error: `there was a problem with ${id}`
+        }
+      } else {
+        item.state[id] = {
+          status: 'success'
+        }
+      }
 
-  const command = shallow(
-    <BatchCommand
-      key={item.text}
-      dispatch={noop}
-      action={item.action}
-      state={item.state}
-      text={item.text}
-      confirm={item.confirm}
-      onSuccess={onSuccess}
-      onError={onError}
-      selection={selected}
-    />
-  );
+      process.nextTick(() => {
+        command.setProps(item)
+      })
+    }
 
-  console.log(command.state())
+    const item = {
+      text: 'Example',
+      action: action,
+      state: {},
+      confirm: noop
+    }
 
-  // const sortableTable = granuleOverview.find('SortableTable');
-  // t.is(sortableTable.length, 1);
-  // const sortableTableWrapper = sortableTable.dive();
-  // t.is(sortableTableWrapper.find('tbody tr td a[href="https://my-bucket.s3.amazonaws.com/my-key-path/my-name"]').length, 1);
+    const command = shallow(
+      <BatchCommand
+        key={item.text}
+        dispatch={noop}
+        action={item.action}
+        state={item.state}
+        text={item.text}
+        confirm={item.confirm}
+        onSuccess={onSuccess}
+        onError={onError}
+        selection={selection}
+        updateDelay={1}
+      />
+    );
+
+    command.instance().start()
+  })
 });

--- a/test/components/form/batch-async-command.js
+++ b/test/components/form/batch-async-command.js
@@ -1,0 +1,68 @@
+'use strict';
+
+import test from 'ava';
+import Adapter from 'enzyme-adapter-react-15';
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import { connect } from 'react-redux';
+import { shallowWithStore } from 'enzyme-redux';
+import { createMockStore } from 'redux-test-utils';
+
+import BatchCommand from '../../../app/scripts/components/form/batch-async-command.js';
+
+configure({ adapter: new Adapter() });
+
+test('collect multiple errors', function (t) {
+  const noop = () => {}
+
+  const onSuccess = (result) => {
+    console.log(result)
+  };
+
+  const onError = (err) => {
+    console.log(err)
+  };
+
+  const action = (id) => {
+    item.state[id] = {
+      status: id.contains('error') ? 'error' : 'success'
+    }
+
+    command.newProps(item)
+  }
+
+  const item = {
+    text: 'Example',
+    action: action,
+    state: {},
+    confirm: noop
+  }
+
+  const selected = [
+    '0-error',
+    '1-pass',
+    '2-error',
+    '3-pass'
+  ];
+
+  const command = shallow(
+    <BatchCommand
+      key={item.text}
+      dispatch={noop}
+      action={item.action}
+      state={item.state}
+      text={item.text}
+      confirm={item.confirm}
+      onSuccess={onSuccess}
+      onError={onError}
+      selection={selected}
+    />
+  );
+
+  console.log(command.state())
+
+  // const sortableTable = granuleOverview.find('SortableTable');
+  // t.is(sortableTable.length, 1);
+  // const sortableTableWrapper = sortableTable.dive();
+  // t.is(sortableTableWrapper.find('tbody tr td a[href="https://my-bucket.s3.amazonaws.com/my-key-path/my-name"]').length, 1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,6 +286,16 @@ asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
 
+assert-argument@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assert-argument/-/assert-argument-1.0.2.tgz#553a75f8f0d898514596d91a70e938185c3ef212"
+  dependencies:
+    is-buffer "^2.0.2"
+    is-date-object "^1.0.1"
+    is-error "^2.2.1"
+    is-promise "^2.1.0"
+    is-string "^1.0.4"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -2666,7 +2676,7 @@ decompress@^3.0.0:
     vinyl-assign "^1.0.1"
     vinyl-fs "^2.2.0"
 
-deep-equal@^1.0.0, deep-equal@~1.0.1:
+deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -2695,7 +2705,7 @@ define-properties@^1.1.2:
     foreach "^2.0.5"
     object-keys "^1.0.8"
 
-defined@^1.0.0, defined@~1.0.0:
+defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
@@ -3045,6 +3055,10 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
+enzyme-redux@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/enzyme-redux/-/enzyme-redux-0.2.1.tgz#7c2ebebc8a4dd62749d632c5a12d5a23bcabc1ff"
+
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
@@ -3076,15 +3090,6 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.0, es-abstract@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.0"
-    is-callable "^1.1.3"
-    is-regex "^1.0.3"
-
 es-abstract@^1.6.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
@@ -3094,6 +3099,15 @@ es-abstract@^1.6.1:
     has "^1.0.1"
     is-callable "^1.1.3"
     is-regex "^1.0.4"
+
+es-abstract@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    is-callable "^1.1.3"
+    is-regex "^1.0.3"
 
 es-to-primitive@^1.1.1:
   version "1.1.1"
@@ -3630,12 +3644,6 @@ fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
-for-each@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
-  dependencies:
-    is-function "~1.0.0"
-
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3718,7 +3726,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@~1.1.0:
+function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
@@ -4378,7 +4386,7 @@ has-yarn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-1.0.0.tgz#89e25db604b725c8f5976fff0addc921b828a5a7"
 
-has@^1.0.0, has@^1.0.1, has@~1.0.1:
+has@^1.0.0, has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
@@ -4732,6 +4740,10 @@ is-buffer@^1.0.2, is-buffer@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
+is-buffer@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.2.tgz#f83a0c5bc453f6431bf83cc2ceff6cbc9d50a83b"
+
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
@@ -4766,7 +4778,7 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-error@^2.2.0:
+is-error@^2.2.0, is-error@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-error/-/is-error-2.2.1.tgz#684a96d84076577c98f4cdb40c6d26a5123bf19c"
 
@@ -4797,10 +4809,6 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-function@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -6053,10 +6061,6 @@ object-inspect@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
 
-object-inspect@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.2.2.tgz#c82115e4fcc888aea14d64c22e4f17f6a70d5e5a"
-
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
@@ -6752,6 +6756,10 @@ react-autocomplete@^1.7.1:
     dom-scroll-into-view "1.0.1"
     prop-types "^15.5.10"
 
+react-collapsible@^2.0.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-collapsible/-/react-collapsible-2.2.0.tgz#257abef5b96a330d9249810761cac29a3d82f268"
+
 react-dom@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
@@ -7165,7 +7173,7 @@ resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@1.1.7, resolve@~1.1.7:
+resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
@@ -7195,12 +7203,6 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
-
-resumer@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
-  dependencies:
-    through "~2.3.4"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -7725,14 +7727,6 @@ string.prototype.codepointat@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz#6b26e9bd3afcaa7be3b4269b526de1b82000ac78"
 
-string.prototype.trim@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.0"
-    function-bind "^1.0.2"
-
 string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -7834,6 +7828,12 @@ strip-outer@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+stubborn-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stubborn-queue/-/stubborn-queue-1.0.0.tgz#1e300562e794033cea87fc9ce16294b630e5a44f"
+  dependencies:
+    assert-argument "^1.0.2"
+
 subarg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
@@ -7928,24 +7928,6 @@ tap-xunit@^1.7.0:
     xmlbuilder "~4.1.0"
     xtend "~4.0.0"
 
-tape@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.6.3.tgz#637e77581e9ab2ce17577e9bd4ce4f575806d8b6"
-  dependencies:
-    deep-equal "~1.0.1"
-    defined "~1.0.0"
-    for-each "~0.3.2"
-    function-bind "~1.1.0"
-    glob "~7.1.1"
-    has "~1.0.1"
-    inherits "~2.0.3"
-    minimist "~1.2.0"
-    object-inspect "~1.2.1"
-    resolve "~1.1.7"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.1.2"
-    through "~2.3.8"
-
 tar-pack@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
@@ -8036,7 +8018,7 @@ through2@^0.6.0, through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.7, through@~2.3, through@~2.3.1, through@~2.3.4, through@~2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.7, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3055,10 +3055,6 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
-enzyme-redux@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/enzyme-redux/-/enzyme-redux-0.2.1.tgz#7c2ebebc8a4dd62749d632c5a12d5a23bcabc1ff"
-
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"


### PR DESCRIPTION
This PR allows a bulk action to continue even if errors are encountered. d3-queue is replaced with a queue module that collects and returns all errors instead of bailing on the first one. Then to make the impact on the codebase as small as possible, the array of errors are combined into one error message to be shown in the ui.