### PR TITLE
CUMULUS-3821: remove fake-granuleid-refresh-connection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- **CUMULUS-3821**
+  - Removed fake-granuleid-refresh-connection/refreshCumulusDbConnection
 - **CUMULUS-3870**
   - Remove launchpad security key information from cypress fixture for `valid-execution.json`
   - Add placeholders for security information with `fakePassword` and `userName`

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -168,10 +168,6 @@ export const getCumulusInstanceMetadata = () => ({
   }
 });
 
-export const refreshCumulusDbConnection = () => (dispatch) => dispatch(
-  getGranule('fake-granuleid-refresh-connection')
-);
-
 export const getGranule = (granuleId, params) => ({
   [CALL_API]: {
     type: types.GRANULE,

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -18,7 +18,6 @@ import {
   listWorkflows,
   applyWorkflowToGranule,
   applyRecoveryWorkflowToGranule,
-  refreshCumulusDbConnection,
 } from '../../actions';
 import {
   collectionName as collectionLabelForId,
@@ -90,7 +89,6 @@ const CollectionOverview = ({
   const [selected, setSelected] = useState([]);
 
   useEffect(() => {
-    dispatch(refreshCumulusDbConnection());
     dispatch(listCollections());
     dispatch(getCumulusInstanceMetadata());
     dispatch(getCollection(collectionName, decodedVersion));

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -11,7 +11,6 @@ import {
   listExecutions,
   listWorkflows,
   getOptionsCollectionName,
-  refreshCumulusDbConnection,
 } from '../../actions';
 import { workflowOptions as workflowSelectOptions } from '../../selectors';
 import { tally, lastUpdated } from '../../utils/format';
@@ -50,7 +49,6 @@ const ExecutionOverview = ({
   const tableColumnsArray = tableColumns({ dispatch });
 
   useEffect(() => {
-    dispatch(refreshCumulusDbConnection());
     dispatch(listWorkflows());
   }, [dispatch]);
 

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -17,7 +17,6 @@ import {
   applyRecoveryWorkflowToGranule,
   getOptionsCollectionName,
   getOptionsProviderName,
-  refreshCumulusDbConnection,
   toggleGranulesTableColumns,
 } from '../../actions';
 import { lastUpdated, tally } from '../../utils/format';
@@ -71,7 +70,6 @@ class GranulesOverview extends React.Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(refreshCumulusDbConnection());
     this.queryMeta();
   }
 

--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -14,7 +14,6 @@ import {
   listCollections,
   listOperations,
   listWorkflows,
-  refreshCumulusDbConnection,
 } from '../../actions';
 import { tally } from '../../utils/format';
 import List from '../Table/Table';
@@ -34,7 +33,6 @@ class OperationOverview extends React.Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(refreshCumulusDbConnection());
     this.queryMeta();
     this.props.dispatch(getCumulusInstanceMetadata());
   }

--- a/app/src/js/components/Pdr/overview.js
+++ b/app/src/js/components/Pdr/overview.js
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { listPdrs, getCount, clearPdrsFilter, filterPdrs, refreshCumulusDbConnection } from '../../actions';
+import { listPdrs, getCount, clearPdrsFilter, filterPdrs } from '../../actions';
 import { lastUpdated, tally } from '../../utils/format';
 import { bulkActions } from '../../utils/table-config/pdrs';
 import { tableColumns } from '../../utils/table-config/pdr-progress';
@@ -35,7 +35,6 @@ class PdrOverview extends React.Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(refreshCumulusDbConnection());
     this.queryStats();
   }
 

--- a/app/src/js/components/Providers/overview.js
+++ b/app/src/js/components/Providers/overview.js
@@ -10,7 +10,6 @@ import {
   getCount,
   filterProviders,
   clearProvidersFilter,
-  refreshCumulusDbConnection,
 } from '../../actions';
 import { lastUpdated } from '../../utils/format';
 import { tableColumns } from '../../utils/table-config/providers';
@@ -25,7 +24,6 @@ class ProvidersOverview extends React.Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(refreshCumulusDbConnection());
     this.queryStats();
   }
 

--- a/app/src/js/components/ReconciliationReports/list.js
+++ b/app/src/js/components/ReconciliationReports/list.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link, withRouter } from 'react-router-dom';
@@ -8,7 +8,6 @@ import {
   clearReconciliationReportsFilter,
   listReconciliationReports,
   filterReconciliationReports,
-  refreshCumulusDbConnection,
 } from '../../actions';
 import { lastUpdated } from '../../utils/format';
 import { reconciliationReportStatus as statusOptions } from '../../utils/status';
@@ -63,10 +62,6 @@ const ReconciliationReportList = ({
   const { queriedAt, count } = list.meta;
   const query = generateQuery();
   const tableColumnsArray = tableColumns({ dispatch, isGranules, query });
-
-  useEffect(() => {
-    dispatch(refreshCumulusDbConnection());
-  }, [dispatch]);
 
   function generateQuery() {
     return {

--- a/app/src/js/components/Rules/overview.js
+++ b/app/src/js/components/Rules/overview.js
@@ -9,7 +9,6 @@ import {
   clearRulesSearch,
   filterRules,
   clearRulesFilter,
-  refreshCumulusDbConnection,
 } from '../../actions';
 import { lastUpdated, tally } from '../../utils/format';
 import List from '../Table/Table';
@@ -35,7 +34,6 @@ class RulesOverview extends React.Component {
   }
 
   componentDidMount() {
-    this.props.dispatch(refreshCumulusDbConnection());
     this.props.dispatch(listRules);
   }
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
   "high": true,
   "pass-enoaudit": true,
   "retry-count": 20,
-  "allowlist": ["braces", "d3-color", "webpack-dev-middleware", "ws"]
+  "allowlist": ["braces", "d3-color", "webpack-dev-middleware", "ws", "jsonpath-plus"]
 }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3821: Remove fake-granuleid-refresh-connection component to fix 404 error issue](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3821)

## Changes

* Remove `fake-granuleid-refresh-connection` component
* Remove `refreshCumulusDbConnection` action from the Redux store
* Fix audit issue with `jsonpath-plus` (whitelisted)

## PR Checklist

- [X] Update CHANGELOG
- [ ] Unit tests
- [X] Adhoc testing
- [ ] Integration tests