### PR TITLE
CUMULUS-4171 - Remove override of pbkdf2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- **CUMULUS-CUMULUS-4171**
+  - Removed override of pbkdf2 ^3.1.3 for crypto-browserify since pbkdf2 ^3.1.3 will be pulled automatically
 - **CUMULUS-3680**
   - Fixed drop-down menus to include all collection and provider options .
   - Removed unnecessary API calls from Operations and Providers pages.

--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
   },
   "overrides": {
     "crypto-browserify": {
-      "pbkdf2": "^3.1.3",
       "elliptic": "^6.6.1"
     },
     "browserify-sign": {


### PR DESCRIPTION
**Summary:** Removing dependency override of pbkdf2 in the crypto-browserify package

Addresses [CUMULUS-4171: Dashboard: upgrade crypto-browserify and remove from package overrides](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4171)

## Changes

* Removed dependency override of pbkdf2 in the crypto-browserify package. The latest minor version of pbkdf2 (currently 3.1.3) with the critical audit fixes will be pulled by crypto-browserify automatically so no override is needed. 

This original issue relates to https://github.com/browserify/crypto-browserify/issues/241

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [x] Integration tests