### PR TITLE
CUMULUS-4451: Disable sort executions by name to avoid slow query in Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- **CUMULUS-4451**
+  - Disable sort executions by name to avoid slow query in Postgres
+  
 ## [v14.1.0] - 2025-12-22
 
 ### Added

--- a/app/src/js/utils/table-config/executions.js
+++ b/app/src/js/utils/table-config/executions.js
@@ -112,7 +112,8 @@ export const tableColumns = ({ dispatch }) => ([
     accessor: 'name',
     width: 150,
     Cell: ({ row: { original: { arn, name } } }) => ( // eslint-disable-line react/prop-types
-      <Link to={(location) => ({ pathname: `/executions/execution/${arn}`, search: getPersistentQueryParams(location) })} title={name}>{name}</Link>)
+      <Link to={(location) => ({ pathname: `/executions/execution/${arn}`, search: getPersistentQueryParams(location) })} title={name}>{name}</Link>),
+    disableSortBy: true
   },
   {
     Header: 'Progress',


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4451: Disable sort executions by name to avoid slow query in Postgres](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4451)

## Changes

* Disable sort executions by name to avoid slow query in Postgres

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests