### PR TITLE
CUMULUS-4451: Set default sort order for executions to -updatedAt to avoid slow query in Postgres.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **CUMULUS-4451**
   - Disable sort executions by name to avoid slow query in Postgres
+  - Set default sort order for executions to -updatedAt to avoid slow query in Postgres
   
 - **CUMULUS-4461**
   - Address qs vulnerability by overriding its version to ^6.14.1

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -683,18 +683,24 @@ export const getExecutionLogs = (executionName) => ({
 
 export const listExecutions = (options) => (dispatch, getState) => {
   const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
+  const params = parseArchivedInListParams({
+    limit: defaultPageLimit,
+    estimateTableRowCount: _config.estimateTableRowCount,
+    ...options,
+    ...timeFilters
+  });
+
+  // If sort_key is missing OR explicitly an empty array, set default
+  if (!params.sort_key || (Array.isArray(params.sort_key) && params.sort_key.length === 0)) {
+    params.sort_key = ['-updatedAt'];
+  }
 
   return dispatch({
     [CALL_API]: {
       type: types.EXECUTIONS,
       method: 'GET',
       url: new URL('executions', root).href,
-      params: parseArchivedInListParams({
-        limit: defaultPageLimit,
-        estimateTableRowCount: _config.estimateTableRowCount,
-        ...options,
-        ...timeFilters
-      })
+      params
     }
   });
 };

--- a/test/actions/archived.js
+++ b/test/actions/archived.js
@@ -97,3 +97,17 @@ test('listExecutionsByGranule calls the api with no archived element if archived
   const dispatchedAction = store.getActions()[0];
   t.false('archived' in dispatchedAction.config.params);
 });
+
+test('listExecutions calls the api with default sort_key ["-updatedAt"].', (t) => {
+  const testState = { ...initialState };
+  testState.startDateTime = null;
+  testState.endDateTime = null;
+
+  const store = mockStore({
+    datepicker: testState
+  });
+
+  store.dispatch(listExecutions({}));
+  const dispatchedAction = store.getActions()[0];
+  t.deepEqual(dispatchedAction.config.params.sort_key, ["-updatedAt"]);
+});


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4451: Set default sort order for executions to -updatedAt to avoid slow query in Postgres](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4451)

## Changes

* Set default sort order for executions to -updatedAt to avoid slow query in Postgres

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [ ] Integration tests