### PR TITLE
CUMULUS-4484: Change INITIAL_DATE_RANGE_IN_DAYS default value to 1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- **CUMULUS-4484**
+  - Change INITIAL_DATE_RANGE_IN_DAYS default value to 1
 - **CUMULUS-4451**
   - Disable sort executions by name to avoid slow query in Postgres
   - Set default sort order for executions to -updatedAt to avoid slow query in Postgres

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Setting the following environment variables can override the default values.
 | LABELS | Select `daac` localization. | *daac* |
 | STAGE | Identifier displayed at top of dashboard page: e.g. PROD, UAT | *development* |
 | KIBANAROOT | \<optional\>  Points to a Kibana endpoint. | |
-| INITIAL_DATE_RANGE_IN_DAYS| \<optional\> Number of days to load up before at start | |
+| INITIAL_DATE_RANGE_IN_DAYS| \<optional\> Number of days to load up before at start | *1* |
 | USE_UTC_TIME_FORMAT| The table's timestamp column's time display format. Expected value is UTC. | |
 | ESTIMATE_TABLE_ROW_COUNT | \<optional\> Toggles estimated row count for Granule and Execution tables | true |
 

--- a/app/src/js/config/config.js
+++ b/app/src/js/config/config.js
@@ -26,7 +26,7 @@ const config = {
   oauthMethod: process.env.AUTH_METHOD || 'earthdata',
   kibanaRoot: process.env.KIBANAROOT || '',
   graphicsPath: process.env.BUCKET || '',
-  initialDateRange: process.env.INITIAL_DATE_RANGE_IN_DAYS || 'All',
+  initialDateRange: process.env.INITIAL_DATE_RANGE_IN_DAYS || 1,
   enableRecovery: computeBool(process.env.ENABLE_RECOVERY, false),
   servedByCumulusAPI: computeBool(process.env.SERVED_BY_CUMULUS_API, ''),
   useUTCTimeFormat: process.env.USE_UTC_TIME_FORMAT || '',

--- a/ava-conditional.config.cjs
+++ b/ava-conditional.config.cjs
@@ -7,7 +7,7 @@ module.exports = {
     HIDE_PDR: 'false',
     KIBANAROOT: 'https://fake.com/linktokibana',
     AUTH_METHOD: 'launchpad',
-    INITIAL_DATE_RANGE_IN_DAYS: '',
+    INITIAL_DATE_RANGE_IN_DAYS: 'All',
     BUCKET: 'https://example.com/bucket',
     STAGE: 'production',
     DAAC_NAME: 'Cumulus_Daac',

--- a/ava-conditional.config.cjs
+++ b/ava-conditional.config.cjs
@@ -7,7 +7,6 @@ module.exports = {
     HIDE_PDR: 'false',
     KIBANAROOT: 'https://fake.com/linktokibana',
     AUTH_METHOD: 'launchpad',
-    INITIAL_DATE_RANGE_IN_DAYS: 'All',
     BUCKET: 'https://example.com/bucket',
     STAGE: 'production',
     DAAC_NAME: 'Cumulus_Daac',

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,7 +6,6 @@ module.exports = defineConfig({
     APIROOT: 'http://localhost:5001',
     authToken: null,
     ESTIMATE_TABLE_ROW_COUNT: true,
-    INITIAL_DATE_RANGE_IN_DAYS: 'All',
   },
   retries: {
     runMode: 2,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,6 +6,7 @@ module.exports = defineConfig({
     APIROOT: 'http://localhost:5001',
     authToken: null,
     ESTIMATE_TABLE_ROW_COUNT: true,
+    INITIAL_DATE_RANGE_IN_DAYS: 'All',
   },
   retries: {
     runMode: 2,

--- a/localAPI/docker-compose-cypress.yml
+++ b/localAPI/docker-compose-cypress.yml
@@ -14,3 +14,4 @@ services:
       - CYPRESS_TESTING=true
       - NODE_ENV=test
       - LOCALSTACK_HOST=localhost
+      - INITIAL_DATE_RANGE_IN_DAYS=All

--- a/localAPI/docker-compose-dashboard.yml
+++ b/localAPI/docker-compose-dashboard.yml
@@ -18,6 +18,7 @@ services:
       - DAAC_NAME=local
       - STAGE=LOCALHOST-Development
       - AUTH_METHOD=earthdata
+      - INITIAL_DATE_RANGE_IN_DAYS=All
   shim:   # empty container to open ports
     image: ${DOCKER_REPOSITORY}node:20.12.2
     command:

--- a/test/reducers/datepicker.js
+++ b/test/reducers/datepicker.js
@@ -17,10 +17,13 @@ test('verify initial state', (t) => {
 });
 
 test('reducer sets initial state to have no set start/end times.', (t) => {
+  const now = Date.now();
   const actual = reducer(undefined, { type: 'ANY' });
   t.is(actual.dateRange.label, 'Custom');
   t.is(actual.dateRange.value, 'Custom');
-  t.is(actual.startDateTime, null);
+  // Check startDateTime is ~1 day ago
+  t.true(actual.startDateTime <= now && actual.startDateTime > now - msPerDay -1000, 
+    `startDateTime ${actual.startDateTime} should be within last 24 hours roughly`);
   t.is(actual.endDateTime, null);
   t.is(actual.hourFormat, '12HR');
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4484: Change INITIAL_DATE_RANGE_IN_DAYS default value to 1](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4484)

## Changes

* Change INITIAL_DATE_RANGE_IN_DAYS default value to 1 to fix the date picker time range does not match metrics range issue on the Dashboard overview page and the timeout error on the Dashboard executions page when INITIAL_DATE_RANGE_IN_DAYS is not set.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [ ] Integration tests