### PR TITLE
CUMULUS-4204: Show granule error messages for failed granules in the granule detail page of the dashboard UPDATED

### DIFF
--- a/app/src/js/components/Granules/granule.js
+++ b/app/src/js/components/Granules/granule.js
@@ -251,7 +251,7 @@ function GranuleOverview({ skipReloadOnMount = false }) {
     get(granules.removed, [granuleId, 'error']),
     get(granules.deleted, [granuleId, 'error']),
     get(recoveryStatusMap, [granuleId, 'error']),
-    (isEmpty(get(granules.map, [granuleId, 'data', 'error'])) || /^("?)(None)\1$/.test(get(granules.map, [granuleId, 'data', 'error', 'Cause']))) ? undefined : get(granules.map, [granuleId, 'data', 'error']),
+    (isEmpty(get(granules.map, [granuleId, 'data', 'error']))) ? undefined : get(granules.map, [granuleId, 'data', 'error']),
   ].filter(Boolean);
 
   if (!granuleRecord || (granuleRecord.inflight && !granule)) return <Loading />;

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -70,7 +70,7 @@ export const tableColumns = [
     Header: 'Error Type',
     accessor: (row) => get(row, 'error.Error', nullValue),
     Cell: ({ row: { original } }) => (
-      (isEmpty(get(original, ['error'])) || /^("?)(None)\1$/.test(get(original, ['error', 'Cause']))) ? nullValue : get(original, 'error.Error', nullValue)
+      (isEmpty(get(original, ['error']))) ? nullValue : get(original, 'error.Error', nullValue)
     ),
     id: 'errorType',
     width: 100
@@ -80,7 +80,7 @@ export const tableColumns = [
     accessor: (row) => get(row, 'error.Cause', nullValue),
     id: 'error',
     Cell: ({ row: { original } }) => ( // eslint-disable-line react/prop-types
-      (isEmpty(get(original, ['error'])) || /^("?)(None)\1$/.test(get(original, ['error', 'Cause']))) ? nullValue : <ErrorReport report={get(original, 'error', nullValue)} truncate={true} disableScroll={true} />
+      (isEmpty(get(original, ['error']))) ? nullValue : <ErrorReport report={get(original, 'error', nullValue)} truncate={true} disableScroll={true} />
     ),
     disableSortBy: true,
     width: 175

--- a/cypress/e2e/granules.cy.js
+++ b/cypress/e2e/granules.cy.js
@@ -1157,7 +1157,7 @@ describe('Dashboard Granules Page', () => {
 
       cy.get('.button__apply-filter').click();
 
-      const noErrorGranuleID = 'MOD09GQ.A1530852.CljGDp.006.2163412421938';
+      const noErrorGranuleID = 'test_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl2';
       const errorGranuleID = 'MOD09GQ.A2417309.YZ9tCV.006.4640974889044_ca2a8dfe';
       cy.get(`[data-value="${noErrorGranuleID}"]`).children().as('noErrorColumns');
       cy.get('@noErrorColumns').eq(4).invoke('text').should('be.eq', '--');
@@ -1168,7 +1168,7 @@ describe('Dashboard Granules Page', () => {
     });
 
     it('Should display error if available in granule overview page', () => {
-      const noErrorGranuleID = 'MOD09GQ.A1530852.CljGDp.006.2163412421938';
+      const noErrorGranuleID = 'test_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl2';
       const errorGranuleID = 'MOD09GQ.A2417309.YZ9tCV.006.4640974889044_ca2a8dfe';
       cy.visit(`/granules/granule/${errorGranuleID}`);
       cy.get('.heading--large').should('have.text', `Granule: ${errorGranuleID}`);

--- a/cypress/e2e/granules.cy.js
+++ b/cypress/e2e/granules.cy.js
@@ -1159,25 +1159,33 @@ describe('Dashboard Granules Page', () => {
 
       const noErrorGranuleID = 'test_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl2';
       const errorGranuleID = 'MOD09GQ.A2417309.YZ9tCV.006.4640974889044_ca2a8dfe';
+      const unknownErrorGranuleID = 'coastal_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl3';
       cy.get(`[data-value="${noErrorGranuleID}"]`).children().as('noErrorColumns');
       cy.get('@noErrorColumns').eq(4).invoke('text').should('be.eq', '--');
       cy.get('@noErrorColumns').eq(5).invoke('text').should('be.eq', '--');
       cy.get(`[data-value="${errorGranuleID}"]`).children().as('errorColumns');
       cy.get('@errorColumns').eq(4).invoke('text').should('be.eq', 'UnexpectedFileSize');
       cy.get('@errorColumns').eq(5).invoke('text').should('match', /errorMessage/);
+      cy.get(`[data-value="${unknownErrorGranuleID}"]`).children().as('unknownErrorColumns');
+      cy.get('@unknownErrorColumns').eq(4).invoke('text').should('be.eq', 'Unknown Error');
+      cy.get('@unknownErrorColumns').eq(5).invoke('text').should('match', /None/);
     });
 
     it('Should display error if available in granule overview page', () => {
       const noErrorGranuleID = 'test_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl2';
       const errorGranuleID = 'MOD09GQ.A2417309.YZ9tCV.006.4640974889044_ca2a8dfe';
+      const unknownErrorGranuleID = 'coastal_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl3';
       cy.visit(`/granules/granule/${errorGranuleID}`);
       cy.get('.heading--large').should('have.text', `Granule: ${errorGranuleID}`);
       cy.get('.error__report').should('be.visible');
       cy.get('.error__report').should('contain.text', 'errorMessage');
-
       cy.visit(`/granules/granule/${noErrorGranuleID}`);
       cy.get('.heading--large').should('have.text', `Granule: ${noErrorGranuleID}`);
       cy.get('.error__report').should('not.exist');
+      cy.visit(`/granules/granule/${unknownErrorGranuleID}`);
+      cy.get('.heading--large').should('have.text', `Granule: ${unknownErrorGranuleID}`);
+      cy.get('.error__report').should('be.visible');
+      cy.get('.error__report').should('contain.text', 'None');
     });
   });
 });

--- a/cypress/e2e/main_page.cy.js
+++ b/cypress/e2e/main_page.cy.js
@@ -186,7 +186,7 @@ describe('Dashboard Home Page', () => {
       cy.clock(ingestEndTime);
       cy.setDatepickerDropdown('3 months');
 
-      cy.get('#Errors').contains('6');
+      cy.get('#Errors').contains('15');
       cy.get('#Collections').contains('2');
       cy.get('#Granules').contains('16');
       cy.get('#Executions').contains('11');

--- a/cypress/fixtures/seeds/granulesFixture.json
+++ b/cypress/fixtures/seeds/granulesFixture.json
@@ -62,10 +62,7 @@
       "execution": "https://console.aws.amazon.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789012:execution:TestSourceIntegrationIngestGranuleStateMachine-MOyI0myKEXzf:7a71f849-57a0-40e7-8fca-5cf796602a07",
       "lastUpdateDateTime": "2018-04-25T21:45:45.524Z",
       "published": true,
-      "error": {
-        "Cause": "\"None\"",
-        "Error": "Unknown Error"
-      },
+      "error": {},
       "productVolume": "17956339",
       "endingDateTime": "2017-11-08T23:59:59.000Z",
       "timeToPreprocess": 0.1,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4204: Show granule error messages for failed granules in the granule detail page of the dashboard](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4204)

## Changes

* Remove unnecessary regex that filter out specific error type
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
For release pull requests, a merge commit may be needed; please follow the release instructions.