### PR TITLE
CSD-103: Unable to execute a workflow from a granule page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- **CSD-103**
+  - Fix granule getExecuteOptions selectHandler not setting workflow state data correctly
+
 ### Breaking Changes
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - **CSD-103**
-  - Fix granule getExecuteOptions selectHandler not setting workflow state data correctly
+  - Fixed the getExecuteOptions select handler in the granule detail view modal to correctly set the workflow state data.
 
 ### Breaking Changes
 

--- a/app/src/js/components/Granules/granule.js
+++ b/app/src/js/components/Granules/granule.js
@@ -199,7 +199,7 @@ function GranuleOverview({ skipReloadOnMount = false }) {
 
   const getExecuteOptions = () => [
     executeDialog({
-      selectHandler: setWorkflow,
+      selectHandler: (_selector, newWorkflow) => setWorkflow(newWorkflow),
       label: 'workflow',
       value: workflow,
       options: workflowOptions,

--- a/cypress/e2e/granules.cy.js
+++ b/cypress/e2e/granules.cy.js
@@ -1008,9 +1008,9 @@ describe('Dashboard Granules Page', () => {
 
     it('Should allow user to select execute workflow option from dropdown when from granule detail page', () => {
       const granuleId = 'test_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl2';
-      const workflowNameOneTest = 'SecondTestWorkflow';
-      const workflowNameTwoTest = 'HelloWorldWorkflow';
+      const workflowNameTest = 'SecondTestWorkflow';
       cy.intercept('GET', `/granules/${granuleId}*`).as('getGranule');
+      cy.intercept('PATCH', /\/granules\/.*/).as('executeWorkflow');
 
       cy.visit('/granules');
       cy.wait(1000);
@@ -1027,20 +1027,17 @@ describe('Dashboard Granules Page', () => {
       cy.get('.modal-body .form__dropdown .dropdown__element .react-select__menu').as('workflow-menu');
       cy.get('@workflow-menu').should('be.visible');
       cy.get('@workflow-menu').get('.react-select__option').each(($option) => {
-        if ($option.text() === workflowNameOneTest) {
+        if ($option.text() === workflowNameTest) {
           cy.wrap($option).click();
         }
       });
-      cy.get('.modal-body .form__dropdown .dropdown__element .react-select__single-value').should('have.text', workflowNameOneTest);
-      cy.get('@workflow-input').click({ force: true });
-      cy.get('@workflow-menu').get('.react-select__option').each(($option) => {
-        if ($option.text() === workflowNameTwoTest) {
-          cy.wrap($option).click();
-        }
+      cy.get('.modal-body .form__dropdown .dropdown__element .react-select__single-value').should('have.text', workflowNameTest);
+      cy.get('.button--submit').click();
+      cy.wait('@executeWorkflow').then(({ request }) => {
+        console.log('Request body:', request.body);
+        expect(request.body.action).to.equal('applyWorkflow');
+        expect(request.body.workflow).to.equal(workflowNameTest);
       });
-      cy.get('.modal-body .form__dropdown .dropdown__element .react-select__single-value').should('have.text', workflowNameTwoTest);
-      cy.get('.button--cancel').click();
-      cy.url().should('include', `granules/granule/${granuleId}`);
     });
   });
 

--- a/cypress/e2e/granules.cy.js
+++ b/cypress/e2e/granules.cy.js
@@ -1005,6 +1005,43 @@ describe('Dashboard Granules Page', () => {
         .and('include', `collectionId=${encodeURIComponent(collectionId)}`)
         .and('include', `search=${searchShort}`);
     });
+
+    it('Should allow user to select execute workflow option from dropdown when from granule detail page', () => {
+      const granuleId = 'test_12345678_123456_metopa_12345_eps_o_coa_1234_ovwcl2';
+      const workflowNameOneTest = 'SecondTestWorkflow';
+      const workflowNameTwoTest = 'HelloWorldWorkflow';
+      cy.intercept('GET', `/granules/${granuleId}*`).as('getGranule');
+
+      cy.visit('/granules');
+      cy.wait(1000);
+      cy.contains('.table .tbody .tr a', granuleId).then(($res) => {
+        expect($res).to.have.attr('href', `/granules/granule/${granuleId}`);
+        cy.wrap($res).click();
+      });
+      cy.wait('@getGranule');
+      cy.get('.heading--large').should('have.text', `Granule: ${granuleId}`);
+      cy.contains('button', 'Options').click();
+      cy.get('.dropdown__menu').contains('Execute').click();
+      cy.get('.modal-body .form__dropdown .dropdown__element input').as('workflow-input');
+      cy.get('@workflow-input').click({ force: true });
+      cy.get('.modal-body .form__dropdown .dropdown__element .react-select__menu').as('workflow-menu');
+      cy.get('@workflow-menu').should('be.visible');
+      cy.get('@workflow-menu').get('.react-select__option').each(($option) => {
+        if ($option.text() === workflowNameOneTest) {
+          cy.wrap($option).click();
+        }
+      });
+      cy.get('.modal-body .form__dropdown .dropdown__element .react-select__single-value').should('have.text', workflowNameOneTest);
+      cy.get('@workflow-input').click({ force: true });
+      cy.get('@workflow-menu').get('.react-select__option').each(($option) => {
+        if ($option.text() === workflowNameTwoTest) {
+          cy.wrap($option).click();
+        }
+      });
+      cy.get('.modal-body .form__dropdown .dropdown__element .react-select__single-value').should('have.text', workflowNameTwoTest);
+      cy.get('.button--cancel').click();
+      cy.url().should('include', `granules/granule/${granuleId}`);
+    });
   });
 
   describe('when ESTIMATE_TABLE_ROW_COUNT is false', () => {

--- a/cypress/e2e/granules.cy.js
+++ b/cypress/e2e/granules.cy.js
@@ -1034,7 +1034,6 @@ describe('Dashboard Granules Page', () => {
       cy.get('.modal-body .form__dropdown .dropdown__element .react-select__single-value').should('have.text', workflowNameTest);
       cy.get('.button--submit').click();
       cy.wait('@executeWorkflow').then(({ request }) => {
-        console.log('Request body:', request.body);
         expect(request.body.action).to.equal('applyWorkflow');
         expect(request.body.workflow).to.equal(workflowNameTest);
       });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CSD-103: Unable to execute a workflow from a granule page](https://bugs.earthdata.nasa.gov/browse/CSD-103)

## Changes

* Fix granule getExecuteOptions selectHandler not setting workflow state data correctly by updating granules.js getExecuteOptions selectHandler to match granule overview.js

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests

---
📝 **Note:**
For most pull requests, please **Squash and merge** to maintain a clean and readable commit history.
For release pull requests, a merge commit may be needed; please follow the release instructions.