### PR TITLE
Sort collection dropdown by latest collection date

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -466,7 +466,11 @@ export const getOptionsCollectionName = (options) => ({
     type: types.OPTIONS_COLLECTIONNAME,
     method: 'GET',
     url: new URL('collections', root).href,
-    params: { limit: 'null', fields: 'name,version', sort_key: ['-timestamp'] }
+    params: {
+      limit: 'null',
+      fields: 'name,version,updatedAt,createdAt',
+      sort_key: ['-updatedAt']
+    }
   }
 });
 

--- a/app/src/js/reducers/collections.js
+++ b/app/src/js/reducers/collections.js
@@ -129,7 +129,14 @@ export default createReducer(initialState, {
     state.list.params[action.paramKey] = null;
   },
   [OPTIONS_COLLECTIONNAME]: (state, action) => {
-    const options = action.data.results.map(({ name, version }) => {
+    const sortedCollections = [...(action.data.results || [])].sort((a, b) => {
+      const firstDate = Date.parse(a.updatedAt || a.createdAt || 0) || 0;
+      const secondDate = Date.parse(b.updatedAt || b.createdAt || 0) || 0;
+
+      return secondDate - firstDate;
+    });
+
+    const options = sortedCollections.map(({ name, version }) => {
       const collectionId = getCollectionId({ name, version });
       return {
         id: collectionId,

--- a/test/reducers/collections.js
+++ b/test/reducers/collections.js
@@ -1,7 +1,10 @@
 'use strict';
 import test from 'ava';
 import reducer from '../../app/src/js/reducers/collections.js';
-import { COLLECTIONS } from '../../app/src/js/actions/types';
+import {
+  COLLECTIONS,
+  OPTIONS_COLLECTIONNAME,
+} from '../../app/src/js/actions/types';
 
 test('reducers/collections', function (t) {
   const initialState = {
@@ -20,4 +23,37 @@ test('reducers/collections', function (t) {
   var newState = reducer(initialState, action);
   // list collections overwrites state.list
   t.deepEqual(newState.list.data.map(d => d.collectionName).sort(), ['norm', 'barry'].sort());
+});
+
+test('reducers/collections options sorted by updated date desc', function (t) {
+  const initialState = { dropdowns: {} };
+  const action = {
+    type: OPTIONS_COLLECTIONNAME,
+    data: {
+      results: [
+        {
+          name: 'older',
+          version: '001',
+          updatedAt: '2024-01-01T00:00:00.000Z'
+        },
+        {
+          name: 'newer',
+          version: '002',
+          updatedAt: '2024-05-01T00:00:00.000Z'
+        },
+        {
+          name: 'fallback',
+          version: '003',
+          createdAt: '2024-03-01T00:00:00.000Z'
+        }
+      ]
+    }
+  };
+
+  const newState = reducer(initialState, action);
+
+  t.deepEqual(
+    newState.dropdowns.collectionName.options.map((option) => option.id),
+    ['newer___002', 'fallback___003', 'older___001']
+  );
 });


### PR DESCRIPTION
Fixes #1192.

The collection filter dropdown in the Granules page was showing older collections ahead of recently updated ones.

I changed the options request to include `updatedAt`/`createdAt` and to ask for `sort_key: ["-updatedAt"]`. I also added a reducer-side sort fallback so the UI still orders newest first even if the API response comes back unordered.

Added a reducer test for this ordering behavior.

What I ran:
- `npx ava test/reducers/collections.js`
- `npx eslint app/src/js/actions/index.js app/src/js/reducers/collections.js`

I also tried `npm run test-unit-only`, but that suite currently fails in this environment on unrelated existing tests (brace/jsdom and oauth modal failures), so I kept verification scoped to the changed reducer path.